### PR TITLE
Add check for whether data is already an object

### DIFF
--- a/www/assets/components/lexrating/default/js/lexrating.js
+++ b/www/assets/components/lexrating/default/js/lexrating.js
@@ -7,7 +7,7 @@ function getRating(objId, holder) {
         action: 'web/count/get',
         id: objId
     }, function(data) {
-        var response = JSON.parse(data);
+        var response = (typeof data === 'object') ? data : JSON.parse(data);
         if (response.object) {
             $(holder).rateit('value', response.object.value);
             var readonly = (response.object.allowedToVote === true) ? false : true;


### PR DESCRIPTION
On a site I've been working on, `data` is already an object (not sure if it's a jQuery issue or what), and that causes the javascript to fail. This change checks whether `data` is an object, and if it is, just passes it along. 
